### PR TITLE
Replace tokio-timer with futures-timer for higher timer resolution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,7 @@ repository = "https://github.com/mre/tokio-batch"
 futures-preview = { version = "0.3.0-alpha.19", features = ["compat"] }
 pin-utils = "0.1.0-alpha.4"
 tokio = "0.1.22"
-tokio-timer = "0.2.11"
-futures01 = { package = "futures", version = "0.1.29" }
+futures-timer = "1.0.2"
 
 [dev-dependencies.doc-comment]
 version = "0.3"


### PR DESCRIPTION
Current timer resolution is low for some use cases: https://github.com/mre/tokio-batch/issues/4

This PR replaces the `tokio-timer` with `futures-timer` for higher resolution.

I still need to compare their implementation to be clear about the following questions:
- [x] (1) Why `tokio-timer` does not support higher resolution timer?
- [x] (2) Is there any problem with the `futures-timer` for higher resolution than `tokio-timer`?
- [x] (3) What's the resolution of `futures-timer`?