### PR TITLE
Update to tokio 0.2 + README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ pin-utils = "0.1.0-alpha.4"
 futures-timer = "2.0.2"
 
 [dev-dependencies]
-tokio = { version = "0.2.2", features = ["macros", "rt-core"] }
+tokio = { version = "0.2", features = ["macros", "rt-core"] }
 
 [dev-dependencies.doc-comment]
 version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,12 @@ edition = "2018"
 repository = "https://github.com/mre/futures-batch"
 
 [dependencies]
-futures-preview = { version = "0.3.0-alpha.19", features = ["compat"] }
+futures = { version = "0.3", features = ["async-await"] }
 pin-utils = "0.1.0-alpha.4"
-tokio = "0.1.22"
 futures-timer = "2.0.2"
+
+[dev-dependencies]
+tokio = "0.2.2"
 
 [dev-dependencies.doc-comment]
 version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ pin-utils = "0.1.0-alpha.4"
 futures-timer = "2.0.2"
 
 [dev-dependencies]
-tokio = "0.2.2"
+tokio = { version = "0.2.2", features = ["macros", "rt-core"] }
 
 [dev-dependencies.doc-comment]
 version = "0.3"

--- a/README.md
+++ b/README.md
@@ -27,16 +27,15 @@ use futures_batch::ChunksTimeoutStreamExt;
 #[tokio::main]
 async fn main() {
     let iter = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_iter();
-    let v = stream::iter(iter)
+    let results = stream::iter(iter)
         .chunks_timeout(5, Duration::new(10, 0))
         .collect::<Vec<_>>();
 
-    assert_eq!(vec![vec![0, 1, 2, 3, 4], vec![5, 6, 7, 8, 9]], v.await);
+    assert_eq!(vec![vec![0, 1, 2, 3, 4], vec![5, 6, 7, 8, 9]], results.await);
 }
 ```
 
-_Note: This is using the [`futures-preview`](https://crates.io/crates/futures-preview) crate.
-Check [this blog post](https://rust-lang-nursery.github.io/futures-rs/blog/2019/04/18/compatibility-layer.html) about the futures-rs compability layer._
+\_Note: This is using the [`futures 0.3`](https://crates.io/crates/futures) crate.
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -24,21 +24,14 @@ use futures::{FutureExt, StreamExt, TryFutureExt};
 use std::time::Duration;
 use futures_batch::ChunksTimeoutStreamExt;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let iter = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_iter();
     let v = stream::iter(iter)
         .chunks_timeout(5, Duration::new(10, 0))
         .collect::<Vec<_>>();
 
-    tokio::run(
-        v.then(|res| {
-            assert_eq!(vec![vec![0, 1, 2, 3, 4], vec![5, 6, 7, 8, 9]], res);
-            future::ready(())
-        })
-        .unit_error()
-        .boxed()
-        .compat(),
-    );
+    assert_eq!(vec![vec![0, 1, 2, 3, 4], vec![5, 6, 7, 8, 9]], v.await);
 }
 ```
 
@@ -48,13 +41,12 @@ Check [this blog post](https://rust-lang-nursery.github.io/futures-rs/blog/2019/
 ## Performance
 
 `futures-batch` imposes very low overhead on your application. For example, it [is even used to batch syscalls](https://github.com/mre/futures-batch/issues/4).  
-Under the hood, we are using [`futures-timer`](https://github.com/async-rs/futures-timer), which allows for microsecond timer resolution. 
+Under the hood, we are using [`futures-timer`](https://github.com/async-rs/futures-timer), which allows for microsecond timer resolution.
 If you find a use-case which is not covered, don't be reluctant to open an issue.
 
 ## Credits
 
-This was taken and adjusted from [futures-util](
-https://github.com/rust-lang-nursery/futures-rs/blob/4613193023dd4071bbd32b666e3b85efede3a725/futures-util/src/stream/chunks.rs) and moved into a separate crate for reusability.
+This was taken and adjusted from [futures-util](https://github.com/rust-lang-nursery/futures-rs/blob/4613193023dd4071bbd32b666e3b85efede3a725/futures-util/src/stream/chunks.rs) and moved into a separate crate for reusability.
 Since then it has been modified to support higher-resolution timers.
 
 Thanks to [arielb1](https://github.com/arielb1), [alexcrichton](https://github.com/alexcrichton/), [doyoubi](https://github.com/doyoubi), [spebern](https://github.com/spebern), [wngr](https://github.com/wngr) for their contributions!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,19 +5,18 @@ extern crate doc_comment;
 #[cfg(test)]
 doctest!("../README.md");
 
-
 use core::mem;
 use core::pin::Pin;
 use futures::stream::{Fuse, FusedStream, Stream};
-use futures::Future;
 use futures::task::{Context, Poll};
+use futures::Future;
 use futures::StreamExt;
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
-use std::time::Duration;
 use futures_timer::Delay;
+use std::time::Duration;
 
 pub trait ChunksTimeoutStreamExt: Stream {
     fn chunks_timeout(self, capacity: usize, duration: Duration) -> ChunksTimeout<Self>
@@ -112,8 +111,7 @@ impl<St: Stream> Stream for ChunksTimeout<St> {
                     // the full one.
                     Some(item) => {
                         if self.items.is_empty() {
-                            *self.as_mut().clock() =
-                                Some(Delay::new(self.duration));
+                            *self.as_mut().clock() = Some(Delay::new(self.duration));
                         }
                         self.as_mut().items().push(item);
                         if self.items.len() >= self.cap {
@@ -142,7 +140,12 @@ impl<St: Stream> Stream for ChunksTimeout<St> {
                 Poll::Pending => {}
             }
 
-            match self.as_mut().clock().as_pin_mut().map(|clock| clock.poll(cx)) {
+            match self
+                .as_mut()
+                .clock()
+                .as_pin_mut()
+                .map(|clock| clock.poll(cx))
+            {
                 Some(Poll::Ready(())) => {
                     *self.as_mut().clock() = None;
                     return Poll::Ready(Some(self.as_mut().take()));
@@ -150,7 +153,7 @@ impl<St: Stream> Stream for ChunksTimeout<St> {
                 Some(Poll::Pending) => {}
                 None => {
                     debug_assert!(
-                        self.as_mut().items().is_empty(),
+                        self.items().is_empty(),
                         "Inner buffer is empty, but clock is available."
                     );
                 }
@@ -192,25 +195,21 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::future;
-    use futures::{stream, FutureExt, StreamExt, TryFutureExt};
+    use futures::{stream, FutureExt, StreamExt};
     use std::iter;
     use std::time::{Duration, Instant};
+    use tokio::runtime::Runtime;
 
     #[test]
     fn messages_pass_through() {
         let v = stream::iter(iter::once(5))
             .chunks_timeout(5, Duration::new(1, 0))
             .collect::<Vec<_>>();
-        tokio::run(
-            v.then(|x| {
-                assert_eq!(vec![vec![5]], x);
-                future::ready(())
-            })
-            .unit_error()
-            .boxed()
-            .compat(),
-        );
+
+        let mut rt = Runtime::new().expect("Failed to create tokio runtime");
+        rt.block_on(async move {
+            assert_eq!(vec![vec![5]], v.await);
+        })
     }
 
     #[test]
@@ -221,15 +220,11 @@ mod tests {
         let chunk_stream = ChunksTimeout::new(stream, 5, Duration::new(1, 0));
 
         let v = chunk_stream.collect::<Vec<_>>();
-        tokio::run(
-            v.then(|res| {
-                assert_eq!(vec![vec![0, 1, 2, 3, 4], vec![5, 6, 7, 8, 9]], res);
-                future::ready(())
-            })
-            .unit_error()
-            .boxed()
-            .compat(),
-        );
+
+        let mut rt = Runtime::new().expect("Failed to create tokio runtime");
+        rt.block_on(async move {
+            assert_eq!(vec![vec![0, 1, 2, 3, 4], vec![5, 6, 7, 8, 9]], v.await);
+        })
     }
 
     #[test]
@@ -240,15 +235,11 @@ mod tests {
         let chunk_stream = ChunksTimeout::new(stream, 5, Duration::new(1, 0));
 
         let v = chunk_stream.collect::<Vec<_>>();
-        tokio::run(
-            v.then(|res| {
-                assert_eq!(vec![vec![1, 2, 3, 4]], res);
-                future::ready(())
-            })
-            .unit_error()
-            .boxed()
-            .compat(),
-        );
+
+        let mut rt = Runtime::new().expect("Failed to create tokio runtime");
+        rt.block_on(async move {
+            assert_eq!(vec![vec![1, 2, 3, 4]], v.await);
+        })
     }
 
     // TODO: use the `tokio-test` and `futures-test-preview` crates
@@ -258,10 +249,8 @@ mod tests {
         let stream0 = stream::iter(iter);
 
         let iter = vec![5].into_iter();
-        let stream1 = stream::iter(iter).then(move |n| {
-            Delay::new(Duration::from_millis(300))
-                .map(move |_| n)
-        });
+        let stream1 = stream::iter(iter)
+            .then(move |n| Delay::new(Duration::from_millis(300)).map(move |_| n));
 
         let iter = vec![6, 7, 8].into_iter();
         let stream2 = stream::iter(iter);
@@ -286,14 +275,9 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        tokio::run(
-            v.then(move |res| {
-                assert_eq!(res, results);
-                future::ready(())
-            })
-            .unit_error()
-            .boxed()
-            .compat(),
-        );
+        let mut rt = Runtime::new().expect("Failed to create tokio runtime");
+        rt.block_on(async move {
+            assert_eq!(v.await, results);
+        });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,6 @@ mod tests {
         );
     }
 
-    // TODO: use the `tokio-test` and `futures-test-preview` crates
     #[tokio::test]
     async fn message_timeout() {
         let iter = vec![1, 2, 3, 4].into_iter();


### PR DESCRIPTION
- move tokio to dev-deps, since it looks like it's only needed for testing
- update tokio to 0.2
- update futures to 0.3, remove preview
- update readme to use async/await & tokio::main
- fix tests

I also ran rustfmt on the source, and there was one spot where clippy suggested I remove `as_mut()` inside the `debug_assert!` on like 153, is that all right? Everything ran fine afterwards.
