### PR TITLE
Use pin_project_lite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/mre/futures-batch"
 
 [dependencies]
 futures = { version = "0.3", features = ["async-await"] }
-pin-utils = "0.1.0-alpha.4"
+pin-project-lite = "0.1"
 futures-timer = "2.0.2"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use futures::Future;
 use futures::StreamExt;
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project_lite::pin_project;
 
 use futures_timer::Delay;
 use std::time::Duration;
@@ -28,27 +28,25 @@ pub trait ChunksTimeoutStreamExt: Stream {
 }
 impl<T: ?Sized> ChunksTimeoutStreamExt for T where T: Stream {}
 
-#[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
-pub struct ChunksTimeout<St: Stream> {
-    stream: Fuse<St>,
-    items: Vec<St::Item>,
-    cap: usize,
-    // https://github.com/rust-lang-nursery/futures-rs/issues/1475
-    clock: Option<Delay>,
-    duration: Duration,
+pin_project! {
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct ChunksTimeout<St: Stream> {
+        #[pin]
+        stream: Fuse<St>,
+        items: Vec<St::Item>,
+        cap: usize,
+        // https://github.com/rust-lang-nursery/futures-rs/issues/1475
+        #[pin]
+        clock: Option<Delay>,
+        duration: Duration,
+    }
 }
-
-impl<St: Unpin + Stream> Unpin for ChunksTimeout<St> {}
 
 impl<St: Stream> ChunksTimeout<St>
 where
     St: Stream,
 {
-    unsafe_unpinned!(items: Vec<St::Item>);
-    unsafe_pinned!(clock: Option<Delay>);
-    unsafe_pinned!(stream: Fuse<St>);
-
     pub fn new(stream: St, capacity: usize, duration: Duration) -> ChunksTimeout<St> {
         assert!(capacity > 0);
 
@@ -62,8 +60,9 @@ where
     }
 
     fn take(mut self: Pin<&mut Self>) -> Vec<St::Item> {
-        let cap = self.cap;
-        mem::replace(self.as_mut().items(), Vec::with_capacity(cap))
+        let this = self.as_mut().project();
+        let cap = this.cap;
+        mem::replace(this.items, Vec::with_capacity(*cap))
     }
 
     /// Acquires a reference to the underlying stream that this combinator is
@@ -87,7 +86,7 @@ where
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
     pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
-        self.stream().get_pin_mut()
+        self.project().stream.get_pin_mut()
     }
 
     /// Consumes this combinator, returning the underlying stream.
@@ -104,18 +103,18 @@ impl<St: Stream> Stream for ChunksTimeout<St> {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         loop {
-            match self.as_mut().stream().poll_next(cx) {
+            match self.as_mut().project().stream.poll_next(cx) {
                 Poll::Ready(item) => match item {
                     // Push the item into the buffer and check whether it is full.
                     // If so, replace our buffer with a new and empty one and return
                     // the full one.
                     Some(item) => {
                         if self.items.is_empty() {
-                            *self.as_mut().clock() = Some(Delay::new(self.duration));
+                            *self.as_mut().project().clock = Some(Delay::new(self.duration));
                         }
-                        self.as_mut().items().push(item);
+                        self.as_mut().project().items.push(item);
                         if self.items.len() >= self.cap {
-                            *self.as_mut().clock() = None;
+                            *self.as_mut().project().clock = None;
                             return Poll::Ready(Some(self.as_mut().take()));
                         } else {
                             // Continue the loop
@@ -129,7 +128,7 @@ impl<St: Stream> Stream for ChunksTimeout<St> {
                         let last = if self.items.is_empty() {
                             None
                         } else {
-                            let full_buf = mem::replace(self.as_mut().items(), Vec::new());
+                            let full_buf = mem::replace(self.as_mut().project().items, Vec::new());
                             Some(full_buf)
                         };
 
@@ -140,20 +139,16 @@ impl<St: Stream> Stream for ChunksTimeout<St> {
                 Poll::Pending => {}
             }
 
-            match self
-                .as_mut()
-                .clock()
-                .as_pin_mut()
-                .map(|clock| clock.poll(cx))
-            {
+            let this = self.as_mut().project();
+            match this.clock.as_pin_mut().map(|clock| clock.poll(cx)) {
                 Some(Poll::Ready(())) => {
-                    *self.as_mut().clock() = None;
+                    *self.as_mut().project().clock = None;
                     return Poll::Ready(Some(self.as_mut().take()));
                 }
                 Some(Poll::Pending) => {}
                 None => {
                     debug_assert!(
-                        self.items().is_empty(),
+                        this.items.is_empty(),
                         "Inner buffer is empty, but clock is available."
                     );
                 }


### PR DESCRIPTION
FYI: This is branched off of my other PR

I'm far from a pin expert. I made the necessary changes and fixed all the compiler errors. It appears to pass the tests without issue. 

Does anyone have more experience with pinning that can comment on this? The `pin_project` macro implements Unpin for us already. AFAIK, we use the `#[pin]` macro on each of the fields that require pinning (what used to be `unsafe_pinned` with `pin-utils`), then make sure you use `project` to access the structs fields in it's implementation. I think that's it?